### PR TITLE
Add profile page layout

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,6 +1,7 @@
 export default defineAppConfig({
   pages: [
-    'pages/index/index'
+    'pages/index/index',
+    'pages/profile/index'
   ],
   window: {
     backgroundTextStyle: 'light',

--- a/src/pages/index/index.scss
+++ b/src/pages/index/index.scss
@@ -1,0 +1,17 @@
+.index {
+  padding: 20px;
+  .banner {
+    background: #f5f5f5;
+    padding: 10px;
+    margin-bottom: 20px;
+    text-align: center;
+    font-size: 14px;
+  }
+  .service {
+    padding: 10px 0;
+    border-bottom: 1px solid #eee;
+    .name {
+      font-size: 16px;
+    }
+  }
+}

--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,5 +1,4 @@
 import { View, Text } from '@tarojs/components'
-import { Button } from '@nutui/nutui-react-taro'
 import { useLoad } from '@tarojs/taro'
 import './index.scss'
 
@@ -10,8 +9,16 @@ export default function Index () {
 
   return (
     <View className='index'>
-      <Text>Hello world!</Text>
-      <Button type='primary'>NutUI Button</Button>
+      <View className='banner'>点击中转，展示图片海报</View>
+      <View className='service'>
+        <Text className='name'>3小时日常保洁</Text>
+      </View>
+      <View className='service'>
+        <Text className='name'>90㎡出租房全房打扫</Text>
+      </View>
+      <View className='service'>
+        <Text className='name'>新房开荒保洁260㎡四层别墅</Text>
+      </View>
     </View>
   )
 }

--- a/src/pages/profile/index.config.ts
+++ b/src/pages/profile/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '个人中心'
+})

--- a/src/pages/profile/index.scss
+++ b/src/pages/profile/index.scss
@@ -1,0 +1,13 @@
+.profile {
+  padding: 20px;
+  .title {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
+  .note {
+    margin-top: 20px;
+    color: #666;
+    font-size: 12px;
+  }
+}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,23 @@
+import { View, Text } from '@tarojs/components'
+import { Cell, CellGroup } from '@nutui/nutui-react-taro'
+import './index.scss'
+
+export default function Profile() {
+  return (
+    <View className='profile'>
+      <View className='title'>个人中心</View>
+      <CellGroup>
+        <Cell title='已抢到的订单' />
+        <Cell title='需要返工的订单' />
+        <Cell title='师傅调整自己的业务种类' />
+        <Cell title='师傅调整自己的接单区域' />
+        <Cell title='和公司介绍' />
+        <Cell title='公众号客服' />
+        <Cell title='推荐使用' />
+      </CellGroup>
+      <View className='note'>
+        <Text>这是平台更新给师傅的提示，标价就是给师傅结算的价，统计在钱包中。</Text>
+      </View>
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- list service examples on the home page
- add a profile page with basic items
- wire profile page into app config

## Testing
- `npm run build:h5`

------
https://chatgpt.com/codex/tasks/task_e_68769c8194588333988fe891a35ddc3f