### PR TITLE
Align local order page with design

### DIFF
--- a/src/pages/localOrders/index.scss
+++ b/src/pages/localOrders/index.scss
@@ -1,7 +1,7 @@
 .local-orders {
-  background: #F5F6FA;
+  background: #F5F7FA;
   min-height: 100vh;
-  padding-bottom: 80px;
+  padding-bottom: 72px;
 
   .carousel {
     margin: 16px;
@@ -18,29 +18,34 @@
   .tabs {
     display: flex;
     height: 48px;
-    margin: 0 16px;
+    padding: 0 16px;
 
     .tab-item {
-      flex: 1;
+      margin-right: 24px;
+      padding: 0 24px;
       display: flex;
       justify-content: center;
       align-items: center;
       font-size: 16px;
       color: #333333;
       position: relative;
+      &:last-child {
+        margin-right: 0;
+      }
 
       &.active {
-        color: #1890FF;
+        color: #E94F3D;
         font-weight: bold;
 
         &::after {
           content: '';
           position: absolute;
-          bottom: 0;
-          left: 20%;
-          right: 20%;
+          bottom: 4px;
+          left: 50%;
+          width: 20px;
           height: 2px;
-          background: #1890FF;
+          background: #E94F3D;
+          transform: translateX(-50%);
           border-radius: 1px;
         }
       }
@@ -49,7 +54,6 @@
 
   .list {
     margin-top: 16px;
-    padding: 0 16px;
 
     .order-card {
       position: relative;
@@ -57,13 +61,15 @@
       background: #FFFFFF;
       border-radius: 8px;
       padding: 12px;
-      margin-bottom: 8px;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+      margin: 8px 16px;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 
       .order-image {
-        width: 48px;
-        height: 48px;
+        width: 74px;
+        height: 74px;
         margin-right: 12px;
+        border-radius: 4px;
+        object-fit: cover;
       }
 
       .order-content {
@@ -71,36 +77,57 @@
 
         .order-title {
           font-size: 16px;
-          color: #333333;
-          font-weight: bold;
-          margin-bottom: 4px;
+          color: #00807F;
+          font-weight: 600;
+          line-height: 24px;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
         }
 
         .order-address {
+          margin-top: 4px;
           font-size: 14px;
-          color: #666666;
-          white-space: nowrap;
+          color: #999999;
+          line-height: 20px;
           overflow: hidden;
-          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
         }
       }
 
       .order-action {
-        width: 60px;
+        margin-left: 16px;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
-      }
 
-      .order-label {
-        position: absolute;
-        bottom: 8px;
-        right: 12px;
-        background: #FFFBE6;
-        color: #FAAD14;
-        border-radius: 4px;
-        font-size: 12px;
-        padding: 2px 4px;
+        .grab-btn {
+          width: 60px;
+          height: 30px;
+          border-radius: 15px;
+          background: linear-gradient(90deg, #FF8C00, #FF6000);
+          color: #FFFFFF;
+          font-size: 14px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .order-label {
+          margin-top: 4px;
+          width: 30px;
+          height: 16px;
+          background: #E94F3D;
+          border-radius: 8px;
+          color: #FFFFFF;
+          font-size: 12px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
       }
     }
   }
@@ -110,7 +137,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 60px;
+    height: 56px;
     display: flex;
     background: #FFFFFF;
     border-top: 1px solid #E8E8E8;
@@ -121,11 +148,11 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      color: #666666;
+      color: #999999;
       font-size: 12px;
 
       &.active {
-        color: #1890FF;
+        color: #007AFF;
       }
     }
   }

--- a/src/pages/localOrders/index.tsx
+++ b/src/pages/localOrders/index.tsx
@@ -65,9 +65,9 @@ export default function LocalOrders() {
               <Text className='order-address'>{order.address}</Text>
             </View>
             <View className='order-action'>
-              <Text>抢单</Text>
+              <Text className='grab-btn'>抢单</Text>
+              <View className='order-label'>{order.source}</View>
             </View>
-            <Text className='order-label'>{order.source}</Text>
           </View>
         ))}
       </View>


### PR DESCRIPTION
## Summary
- tweak layout and colors for `localOrders`
- adjust tab styling and active underline
- update order card spacing, typography and action buttons
- restyle bottom navigation

## Testing
- `npx eslint src/pages/localOrders/index.tsx` *(fails: ESLint couldn't find configuration)*
- `npx -y stylelint "src/**/*.scss"` *(fails: missing stylelint-config-standard)*
- `npm run build:h5` *(fails: `taro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876acfbdb548333bcb3d2d2a242aa15