### PR TITLE
Add local orders page

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,7 +1,8 @@
 export default defineAppConfig({
   pages: [
     'pages/index/index',
-    'pages/profile/index'
+    'pages/profile/index',
+    'pages/localOrders/index'
   ],
   window: {
     backgroundTextStyle: 'light',

--- a/src/pages/localOrders/index.config.ts
+++ b/src/pages/localOrders/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '本地订单'
+})

--- a/src/pages/localOrders/index.scss
+++ b/src/pages/localOrders/index.scss
@@ -1,0 +1,314 @@
+.local-orders {
+  background: #F5F6FA;
+  min-height: 100vh;
+  padding-bottom: 80px;
+
+  .carousel {
+    margin: 16px;
+    height: 180px;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .carousel-img {
+    width: 100%;
+    height: 100%;
+  }
+
+  .tabs {
+    display: flex;
+    height: 48px;
+    margin: 0 16px;
+
+    .tab-item {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 16px;
+      color: #333333;
+      position: relative;
+
+      &.active {
+        color: #1890FF;
+        font-weight: bold;
+
+        &::after {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: 20%;
+          right: 20%;
+          height: 2px;
+          background: #1890FF;
+          border-radius: 1px;
+        }
+      }
+    }
+  }
+
+  .list {
+    margin-top: 16px;
+    padding: 0 16px;
+
+    .order-card {
+      position: relative;
+      display: flex;
+      background: #FFFFFF;
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 8px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+
+      .order-image {
+        width: 48px;
+        height: 48px;
+        margin-right: 12px;
+      }
+
+      .order-content {
+        flex: 1;
+
+        .order-title {
+          font-size: 16px;
+          color: #333333;
+          font-weight: bold;
+          margin-bottom: 4px;
+        }
+
+        .order-address {
+          font-size: 14px;
+          color: #666666;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+
+      .order-action {
+        width: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        .order-lock {
+          font-size: 24px;
+          color: #999999;
+        }
+      }
+
+      .order-label {
+        position: absolute;
+        bottom: 8px;
+        right: 12px;
+        background: #FFFBE6;
+        color: #FAAD14;
+        border-radius: 4px;
+        font-size: 12px;
+        padding: 2px 4px;
+      }
+    }
+  }
+
+  .bottom-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    display: flex;
+    background: #FFFFFF;
+    border-top: 1px solid #E8E8E8;
+
+    .bottom-item {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      color: #666666;
+      font-size: 12px;
+
+      &.active {
+        color: #1890FF;
+      }
+    }
+  }
+
+  .modal-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+
+    .order-modal {
+      width: 85%;
+      max-height: 80vh;
+      background: #FFFFFF;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      animation: modal-fade 300ms;
+      position: relative;
+
+      .close-btn {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        width: 24px;
+        height: 24px;
+        line-height: 24px;
+        text-align: center;
+        font-size: 20px;
+        color: #999999;
+      }
+
+      .modal-title {
+        height: 56px;
+        line-height: 56px;
+        text-align: center;
+        background: #F0FAFF;
+        color: #FA8C16;
+        font-weight: bold;
+        font-size: 18px;
+        border-bottom: 1px solid #E8E8E8;
+        margin: -20px -20px 0;
+        border-top-left-radius: 8px;
+        border-top-right-radius: 8px;
+      }
+
+      .modal-content {
+        flex: 1;
+        overflow-y: auto;
+        padding-top: 16px;
+
+        .service-info {
+          display: flex;
+          margin-bottom: 16px;
+
+          .service-icon {
+            width: 24px;
+            height: 24px;
+            border-radius: 4px;
+            margin-right: 8px;
+          }
+
+          .service-text {
+            .service-name {
+              font-size: 16px;
+              color: #333333;
+              font-weight: bold;
+            }
+
+            .service-desc {
+              margin-top: 4px;
+              font-size: 14px;
+              color: #666666;
+            }
+          }
+        }
+
+        .thumbnail {
+          display: flex;
+          align-items: center;
+          margin-bottom: 16px;
+
+          .thumb-img {
+            width: 72px;
+            height: 72px;
+            border-radius: 4px;
+            background: #F0F0F0;
+            margin-right: 8px;
+          }
+
+          .thumb-arrow {
+            font-size: 12px;
+            color: #999999;
+          }
+        }
+
+        .info-row {
+          display: flex;
+          align-items: center;
+          margin-bottom: 16px;
+
+          .row-icon {
+            width: 20px;
+            height: 20px;
+            margin-right: 8px;
+            color: #1890FF;
+          }
+
+          .row-text {
+            flex: 1;
+            font-size: 14px;
+            color: #333333;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .row-link {
+            font-size: 16px;
+            color: #1890FF;
+            margin-left: 8px;
+          }
+
+          .row-call {
+            display: flex;
+            align-items: center;
+            margin-left: 8px;
+
+            .call-icon {
+              margin-right: 4px;
+              color: #1890FF;
+            }
+          }
+        }
+      }
+
+      .modal-action {
+        margin-top: 24px;
+        height: 56px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        .action-btn {
+          width: 100%;
+          height: 44px;
+          line-height: 44px;
+          text-align: center;
+          border-radius: 4px;
+          background: #FA8C16;
+          color: #FFFFFF;
+          font-size: 16px;
+
+          &.disabled {
+            background: #F5F5F5;
+            color: #CCCCCC;
+          }
+        }
+      }
+    }
+  }
+}
+
+@keyframes modal-fade {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/pages/localOrders/index.tsx
+++ b/src/pages/localOrders/index.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+import { View, Text, Swiper, SwiperItem, Image } from '@tarojs/components'
+import Taro from '@tarojs/taro'
+import './index.scss'
+import banner from '../../../product.jpg'
+
+interface Order {
+  id: number
+  title: string
+  address: string
+  source: string
+  desc: string
+  time: string
+  client: string
+  phone: string
+  images: string[]
+}
+
+const orders: Order[] = [
+  {
+    id: 1,
+    title: '3小时日常保洁',
+    address: '北京市朝阳区示例路100号',
+    source: '平台',
+    desc: '家庭日常保洁，时长约3小时',
+    time: '2025-07-01 10:00',
+    client: '张三',
+    phone: '13800000001',
+    images: [banner]
+  },
+  {
+    id: 2,
+    title: '90㎡出租房全房打扫',
+    address: '上海市浦东新区示例路200号',
+    source: '微信',
+    desc: '出租前全面打扫，包含窗户与厨房',
+    time: '2025-07-02 14:30',
+    client: '李四',
+    phone: '13800000002',
+    images: [banner]
+  },
+  {
+    id: 3,
+    title: '新房开荒保洁260㎡四层别墅',
+    address: '广州市天河区示例路300号',
+    source: '线下',
+    desc: '别墅开荒保洁，4层共260㎡',
+    time: '2025-07-03 09:00',
+    client: '王五',
+    phone: '13800000003',
+    images: [banner]
+  }
+]
+
+export default function LocalOrders() {
+  const [tab, setTab] = useState(0)
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null)
+  const [grabbedOrders, setGrabbedOrders] = useState<number[]>([])
+  const grabbed = selectedOrder ? grabbedOrders.includes(selectedOrder.id) : false
+
+  return (
+    <View className='local-orders'>
+      <Swiper
+        className='carousel'
+        circular
+        autoplay
+        interval={5000}
+        indicatorDots
+        indicatorColor='#CCCCCC'
+        indicatorActiveColor='#1890FF'
+      >
+        <SwiperItem>
+          <Image className='carousel-img' src={banner} mode='aspectFill' />
+        </SwiperItem>
+        <SwiperItem>
+          <Image className='carousel-img' src={banner} mode='aspectFill' />
+        </SwiperItem>
+      </Swiper>
+
+      <View className='tabs'>
+        <View
+          className={`tab-item ${tab === 0 ? 'active' : ''}`}
+          onClick={() => setTab(0)}
+        >
+          本地订单
+        </View>
+        <View
+          className={`tab-item ${tab === 1 ? 'active' : ''}`}
+          onClick={() => setTab(1)}
+        >
+          全国订单
+        </View>
+      </View>
+
+      <View className='list'>
+        {orders.map((order) => {
+          const grabbed = grabbedOrders.includes(order.id)
+          return (
+            <View
+              key={order.id}
+              className='order-card'
+              onClick={() => setSelectedOrder(order)}
+            >
+              <Image className='order-image' src={banner} mode='aspectFill' />
+              <View className='order-content'>
+                <Text className='order-title'>{order.title}</Text>
+                <Text className='order-address'>{order.address}</Text>
+              </View>
+              <View className='order-action'>
+                {grabbed ? <Text className='order-lock'>🔒</Text> : <Text>抢单</Text>}
+              </View>
+              <Text className='order-label'>{order.source}</Text>
+            </View>
+          )
+        })}
+      </View>
+
+      <View className='bottom-bar'>
+        <View className='bottom-item active'>
+          <Text>首页</Text>
+        </View>
+        <View className='bottom-item'>
+          <Text>消息</Text>
+        </View>
+        <View className='bottom-item'>
+          <Text>账户</Text>
+        </View>
+      </View>
+
+      {selectedOrder && (
+        <View className='modal-mask' onClick={() => setSelectedOrder(null)}>
+          {/* Modal */}
+          <View
+            className='order-modal'
+            onClick={(e) => e.stopPropagation()}
+          >
+            <View className='close-btn' onClick={() => setSelectedOrder(null)}>
+              ×
+            </View>
+            <View className='modal-title'>订单详情</View>
+            <View className='modal-content'>
+              <View className='service-info'>
+                <Image className='service-icon' src={banner} mode='aspectFill' />
+                <View className='service-text'>
+                  <Text className='service-name'>{selectedOrder.title}</Text>
+                  <Text className='service-desc'>{selectedOrder.desc}</Text>
+                </View>
+              </View>
+
+              <View className='thumbnail'>
+                <Image className='thumb-img' src={selectedOrder.images[0]} mode='aspectFill' />
+                <Text className='thumb-arrow'>›</Text>
+              </View>
+
+              <View className='info-row'>
+                <Text className='row-icon'>🕒</Text>
+                <Text className='row-text'>{selectedOrder.time}</Text>
+              </View>
+              <View className='info-row'>
+                <Text className='row-icon'>📍</Text>
+                <Text className='row-text'>{selectedOrder.address}</Text>
+                <Text className='row-link'>查看地图</Text>
+              </View>
+              <View className='info-row'>
+                <Text className='row-icon'>👤</Text>
+                <Text className='row-text'>{selectedOrder.client}</Text>
+              </View>
+              <View className='info-row'>
+                <Text className='row-icon'>📞</Text>
+                <Text className='row-text'>{selectedOrder.phone}</Text>
+                <View className='row-call'>
+                  <Text className='call-icon'>📞</Text>
+                  <Text className='row-link'>可拨打电话</Text>
+                </View>
+              </View>
+            </View>
+
+            <View className='modal-action'>
+              <View
+                className={`action-btn ${grabbed ? 'disabled' : ''}`}
+                onClick={() => {
+                  if (grabbed) return
+                  setGrabbedOrders([...grabbedOrders, selectedOrder.id])
+                  Taro.showModal({
+                    title: '联系客户',
+                    content: `是否拨打客户电话？`,
+                    success: (res) => {
+                      if (res.confirm) {
+                        Taro.makePhoneCall({ phoneNumber: selectedOrder.phone })
+                      }
+                    }
+                  })
+                }}
+              >
+                {grabbed ? '已抢' : '抢单'}
+              </View>
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- show new `localOrders` page for cleaning requests
- update app config to register the page
- implement order details modal with grab button
- improve grabbing interaction and show lock icon when taken

## Testing
- `pnpm install`
- `npm run build:h5` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6876a6a1662c83339acc5eb40a9853f1