### PR TITLE
Add messages page

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -2,7 +2,8 @@ export default defineAppConfig({
   pages: [
     'pages/index/index',
     'pages/profile/index',
-    'pages/localOrders/index'
+    'pages/localOrders/index',
+    'pages/messages/index'
   ],
   window: {
     backgroundTextStyle: 'light',

--- a/src/pages/messages/index.config.ts
+++ b/src/pages/messages/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '消息'
+})

--- a/src/pages/messages/index.scss
+++ b/src/pages/messages/index.scss
@@ -1,0 +1,203 @@
+.messages {
+  background: #F5F7FA;
+  min-height: 100vh;
+  padding-bottom: 72px;
+
+  .title-bar {
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 16px;
+
+    .home {
+      width: 24px;
+      height: 24px;
+    }
+
+    .title {
+      font-size: 18px;
+      font-family: 'Microsoft Yahei', sans-serif;
+      color: #222;
+    }
+
+    .ops {
+      display: flex;
+      .op {
+        margin-left: 12px;
+        font-size: 18px;
+      }
+    }
+  }
+
+  .tabs {
+    display: flex;
+    height: 48px;
+    padding: 0 16px;
+    align-items: center;
+
+    .tab-item {
+      margin-right: 24px;
+      padding: 0 12px;
+      font-size: 16px;
+      color: #666;
+      position: relative;
+
+      &.active {
+        color: #FF5722;
+        &::after {
+          content: '';
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          height: 2px;
+          background: #FF5722;
+        }
+      }
+
+      .badge {
+        position: absolute;
+        top: -4px;
+        right: -4px;
+        background: #FF3B30;
+        color: #fff;
+        font-size: 12px;
+        padding: 0 4px;
+        height: 16px;
+        line-height: 16px;
+        border-radius: 8px;
+      }
+    }
+  }
+
+  .orders {
+    .order-card {
+      display: flex;
+      background: #fff;
+      border-radius: 4px;
+      padding: 12px;
+      margin: 8px 16px;
+      box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+      align-items: center;
+
+      .order-icon {
+        width: 56px;
+        height: 56px;
+        border-radius: 4px;
+        margin-right: 12px;
+        object-fit: cover;
+      }
+
+      .order-content {
+        flex: 1;
+        overflow: hidden;
+        .order-title {
+          font-size: 16px;
+          font-family: 'Microsoft Yahei', sans-serif;
+          font-weight: 500;
+          color: #009688;
+        }
+        .order-address {
+          margin-top: 4px;
+          font-size: 14px;
+          color: #777;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+      }
+
+      .detail-btn {
+        width: 64px;
+        height: 28px;
+        background: #FF5722;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: 16px;
+      }
+    }
+
+    .empty {
+      text-align: center;
+      padding: 48px 0;
+      font-size: 16px;
+      color: #999;
+    }
+  }
+
+  .platform {
+    .group-header {
+      font-size: 12px;
+      color: #999;
+      background: #F5F5F5;
+      height: 28px;
+      line-height: 28px;
+      padding: 0 16px;
+      margin-top: 24px;
+      margin-bottom: 8px;
+    }
+
+    .platform-card {
+      background: #fff;
+      border-radius: 4px;
+      box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+      padding: 12px;
+      margin: 8px 16px;
+
+      .cover {
+        width: 100%;
+        height: 120px;
+        border-radius: 4px 4px 0 0;
+        object-fit: cover;
+      }
+
+      .card-title {
+        margin-top: 8px;
+        font-size: 18px;
+        color: #222;
+        font-weight: bold;
+      }
+
+      .card-summary {
+        margin-top: 4px;
+        font-size: 14px;
+        color: #555;
+        line-height: 20px;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+    }
+  }
+
+  .bottom-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 56px;
+    display: flex;
+    background: #fff;
+    border-top: 1px solid #e8e8e8;
+
+    .bottom-item {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #999;
+      font-size: 12px;
+
+      &.active {
+        color: #007AFF;
+      }
+    }
+  }
+}

--- a/src/pages/messages/index.tsx
+++ b/src/pages/messages/index.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import { View, Text, Image } from '@tarojs/components'
+import Taro from '@tarojs/taro'
+import './index.scss'
+import banner from '../../../product.jpg'
+
+interface OrderMsg {
+  id: number
+  title: string
+  address: string
+  icon: string
+}
+
+const initialOrders: OrderMsg[] = [
+  { id: 1, title: '90m\u00b2\u51fa\u79df\u623f\u5168\u623f\u6253\u626b', address: ' \u5408\u80a5\u5e02\u8755\u5c71\u533a...', icon: banner },
+  { id: 2, title: '3\u5c0f\u65f6\u65e5\u5e38\u4fdd\u6d01', address: ' \u5408\u80a5\u5e02\u8755\u5c71\u533a...', icon: banner }
+]
+
+interface PlatformMsg {
+  id: number
+  title: string
+  summary: string
+  cover: string
+  date: string
+}
+
+const platformGroups: { date: string; items: PlatformMsg[] }[] = [
+  {
+    date: ' \u5468\u4e00 17:01',
+    items: [
+      {
+        id: 1,
+        title: ' \u5e73\u53f0\u6d3b\u52a8\u66f4\u65b0',
+        summary: ' \u65b0\u7684\u4f18\u60e0\u6d3b\u52a8\u5df2\u4e0a\u7ebf',
+        cover: banner,
+        date: ' \u5468\u4e00 17:01'
+      }
+    ]
+  },
+  {
+    date: ' \u5468\u65e5 10:00',
+    items: [
+      {
+        id: 2,
+        title: ' \u5e73\u53f0\u5347\u7ea7\u901a\u77e5',
+        summary: ' \u7cfb\u7edf\u529f\u80fd\u53d1\u751f\u8fdb\u4e00\u6b65\u5347\u7ea7',
+        cover: banner,
+        date: ' \u5468\u65e5 10:00'
+      }
+    ]
+  }
+]
+
+export default function Messages() {
+  const [tab, setTab] = useState(0)
+  const [orders, setOrders] = useState(initialOrders)
+
+  const markRead = (id: number) => {
+    setOrders((prev) => prev.filter((m) => m.id !== id))
+  }
+
+  return (
+    <View className='messages'>
+      <View className='title-bar'>
+        <Text className='home' onClick={() => Taro.navigateTo({ url: '/pages/index/index' })}>\u2302</Text>
+        <Text className='title'>\u6d88\u606f</Text>
+        <View className='ops'>
+          <Text className='op'>\u00b7\u00b7\u00b7</Text>
+          <Text className='op'>\ud83d\udcbb</Text>
+        </View>
+      </View>
+      <View className='tabs'>
+        <View className={`tab-item ${tab === 0 ? 'active' : ''}`} onClick={() => setTab(0)}>
+          \u8ba2\u5355\u6d88\u606f
+          {orders.length > 0 && tab !== 0 && <View className='badge'>{orders.length}</View>}
+        </View>
+        <View className={`tab-item ${tab === 1 ? 'active' : ''}`} onClick={() => setTab(1)}>
+          \u5e73\u53f0\u6d88\u606f
+        </View>
+      </View>
+
+      {tab === 0 ? (
+        <View className='orders'>
+          {orders.length === 0 ? (
+            <View className='empty'>\u6682\u65e0\u65b0\u7684\u8ba2\u5355\u6d88\u606f</View>
+          ) : (
+            orders.map((msg) => (
+              <View key={msg.id} className='order-card'>
+                <Image className='order-icon' src={msg.icon} mode='aspectFill' />
+                <View className='order-content'>
+                  <Text className='order-title'>{msg.title}</Text>
+                  <Text className='order-address'>{msg.address}</Text>
+                </View>
+                <View className='detail-btn' onClick={() => markRead(msg.id)}>
+                  \u67e5\u770b\u8be6\u60c5
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+      ) : (
+        <View className='platform'>
+          {platformGroups.map((group) => (
+            <View key={group.date} className='group'>
+              <View className='group-header'>{group.date}</View>
+              {group.items.map((item) => (
+                <View key={item.id} className='platform-card'>
+                  <Image className='cover' src={item.cover} mode='aspectFill' />
+                  <Text className='card-title'>{item.title}</Text>
+                  <Text className='card-summary'>{item.summary}</Text>
+                </View>
+              ))}
+            </View>
+          ))}
+        </View>
+      )}
+
+      <View className='bottom-bar'>
+        <View className='bottom-item'>
+          <Text>\u9996\u9875</Text>
+        </View>
+        <View className='bottom-item active'>
+          <Text>\u6d88\u606f</Text>
+        </View>
+        <View className='bottom-item'>
+          <Text>\u8d26\u6237</Text>
+        </View>
+      </View>
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- add Messages page with tabs for order and platform notices
- include basic styling and sample content
- register the new page in the app config

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877d7ab005c8333ad8a1fe1ae5eb156